### PR TITLE
example for setting description on content added

### DIFF
--- a/examples/python/createArchiveExample.py
+++ b/examples/python/createArchiveExample.py
@@ -26,8 +26,9 @@ def createArchiveExample(fileName):
         True  # mark file as master
     )
 
+    # add metadata to the archive itself
     description = OmexDescription()
-    description.setAbout(".")  # about the archive itself
+    description.setAbout(".")
     description.setDescription("Simple test archive including one SBML model")
     description.setCreated(OmexDescription.getCurrentDateAndTime())
 
@@ -41,6 +42,15 @@ def createArchiveExample(fileName):
 
     archive.addMetadata(".", description)
 
+    # add metadata to the added file
+    location = "./models/model.xml"
+    description = OmexDescription()
+    description.setAbout(location)
+    description.setDescription("SBML model")
+    description.setCreated(OmexDescription.getCurrentDateAndTime())
+    archive.addMetadata(location, description)
+
+    # write the archive
     out_file = "testdata/out.omex"
     archive.writeToFile(out_file)
 


### PR DESCRIPTION
Setting of metadata like description is not working on entries.