### PR TITLE
Replace deprecated $function by new $action

### DIFF
--- a/src/bindings/swig/libcombine.i
+++ b/src/bindings/swig/libcombine.i
@@ -40,7 +40,7 @@
 
 %exception {
 	try {
-		$function
+		$action
 	} catch(const std::exception& ex) {
 		SWIG_exception(SWIG_RuntimeError, ex.what());
 	} catch(...) {


### PR DESCRIPTION
The long-deprecated $function was removed from future SWIG 4.4.0. It can be safely replaced by $action.

More information about swig change could be found in the commit [Remove long-deprecated $function variable](https://github.com/swig/swig/commit/3be7697a33c98435865fc713f8ecf7cf10765f13)